### PR TITLE
Rebrand all "Code for Seattle" to "Open Seattle"

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-codeforseattle.org
+openseattle.org

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# [codeforseattle.org](http://codeforseattle.org)
+# [openseattle.org](http://openseattle.org)
 
-This is the repo for codeforseattle.org.
+This is the repo for openseattle.org.
 
 ## Contributing:
 - fork the repo

--- a/_config.yml
+++ b/_config.yml
@@ -10,17 +10,16 @@ gems:
 - jekyll-json
 
 brigade:
-    name: Code for Seattle
+    name: Open Seattle
     city:   "Seattle, WA"
-    meetup-link: "http://www.meetup.com/Code-for-Seattle/"
-    google-group: "https://groups.google.com/forum/#!forum/codeforseattle"
-    github: "https://github.com/codeforseattle"
+    meetup-link: "http://www.meetup.com/OpenSeattle/"
+    github: "https://github.com/openseattle"
     idea-list: "http://seattlewiki.net/Code_for_Seattle_ideas"
 
 content:
     title: Code for Seattle
-    meetup-invite: "http://www.meetup.com/Code-for-Seattle/"
-    contact: "info@seattlewiki.net"
+    meetup-invite: "http://www.meetup.com/OpenSeattle/"
+    contact: "hi@openseattle.org"
     banner: ./images/banner.jpg
     projects:
       - name: "SeattleWiki.net"
@@ -40,10 +39,10 @@ content:
         link: "http://seattle-blogs.herokuapp.com/"
       - name: "Ruby LocalWiki client"
         card-img: "http://imgur.com/JUygPil.png"
-        link: "https://github.com/codeforseattle/localwiki_client"
+        link: "https://github.com/openseattle/localwiki_client"
       - name: "Node.js LocalWiki client"
         card-img: "http://imgur.com/FTCRgDE.png"
-        link: "https://github.com/codeforseattle/node-localwiki-client"
+        link: "https://github.com/openseattle/node-localwiki-client"
 
 
 google-analytics:

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -142,8 +142,8 @@
   description: "Use the data from LocalWiki in your JavaScript projects!"
   project_tags: null
   technology_tags: [javascript, node, api]
-  code_url: "https://github.com/codeforseattle/node-localwiki-client"
-  github_user: "codeforseattle"
+  code_url: "https://github.com/openseattle/node-localwiki-client"
+  github_user: "openseattle"
   github_repo:  "node-localwiki-client"
   link_url: null
   status: null
@@ -158,8 +158,8 @@
   description: "Use the data from LocalWiki in your Ruby projects!"
   project_tags: null
   technology_tags: [ruby, api]
-  code_url: "https://github.com/codeforseattle/localwiki_client"
-  github_user: "codeforseattle"
+  code_url: "https://github.com/openseattle/localwiki_client"
+  github_user: "openseattle"
   github_repo:  "localwiki_client"
   link_url: null
   status: null
@@ -420,8 +420,8 @@
   description: null
   project_tags: design
   technology_tags: null
-  code_url: "http://github.com/codeforseattle/seattle-icons"
-  github_user: "codeforseattle"
+  code_url: "http://github.com/openseattle/seattle-icons"
+  github_user: "openseattle"
   github_repo: "seattle-icons"
   link_url: "seattleicons.org"
   status: null
@@ -436,10 +436,10 @@
   description: null
   project_tags: null
   technology_tags: null
-  code_url: "http://github.com/codeforseattle/metrocuts"
+  code_url: "http://github.com/openseattle/metrocuts"
   github_repo: "metrocuts"
-  github_user: "codeforseattle"
-  link_url: "codeforseattle.org/metrocuts"
+  github_user: "openseattle"
+  link_url: "openseattle.org/metrocuts"
   status: null
   contributors: null
   screenshot_url: null

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -2,9 +2,9 @@
   <li><a href="{{ site.baseurl }}/about">About</a></li>
   <li><a href="{{ site.baseurl }}/projects">Projects</a></li>
   <li><a href="{{ site.baseurl }}/guides">Guides</a></li>
-  <li><a href="https://discuss.codeforseattle.org">Discuss</a></li>
+  <li><a href="https://discuss.openseattle.org">Discuss</a></li>
   <li><a href="{{ site.baseurl }}/events">Events</a></li>
   <li><a href="{{ site.baseurl }}/blog">Blog</a></li>
-  <li><a href="https://github.com/codeforseattle" target="_blank">GitHub</a></li>
+  <li><a href="https://github.com/openseattle" target="_blank">GitHub</a></li>
   <li><a href="{{ site.baseurl }}/contact">Contact</a></li>
 </ul>

--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -1,6 +1,6 @@
 <section id="newsletter">
 	<div id="mc_embed_signup">
-		<form action="http://codeforseattle.us3.list-manage2.com/subscribe/post?u=f405e5b88dbe4706a8854768b&amp;id=d0d6ff42a4" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+		<form action="http://openseattle.us3.list-manage2.com/subscribe/post?u=f405e5b88dbe4706a8854768b&amp;id=d0d6ff42a4" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
 			<div id="mce-responses" class="clear">
 				<div class="response" id="mce-error-response" style="display:none"></div>
 				<div class="response" id="mce-success-response" style="display:none"></div>

--- a/_includes/upcoming.html
+++ b/_includes/upcoming.html
@@ -1,5 +1,5 @@
 <div class="section upcoming" style="text-align:center;">
-  <a href="http://www.meetup.com/Code-for-Seattle" target="_blank">
+  <a href="http://www.meetup.com/openseattle" target="_blank">
     <h2 class="title">Join us at our weekly meetups!</h2>
     <p>We meet almost every Wednesday from 5:45 to 9 p.m. Sign up at Meetup.com.</p>
   </a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>
       {% if page.title %}
-        {{ page.title }} ~ Code for Seattle
+        {{ page.title }} ~ Open Seattle
       {% else %}
         {{ site.content.title }} 
       {% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,11 +6,11 @@ layout: default
   <header class="page">
     <div class="inner-wrapper">
       {% include header-page.html %}
-      <h1 class="site-title">Code <span>for</span> Seattle</h1>
+      <h1 class="site-title">Open Seattle</h1>
       <p class="site-description"><i>Seattle residents using technology to support civic engagement and address local issues.</i></p>
       {% include navbar.html %}
-      <p style="text-align: center; margin-bottom:0px;"><a href="https://twitter.com/code4seattle" class="twitter-follow-button" data-show-count="false" data-lang="en">Follow @code4seattle</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script></p>
-      <iframe src="//www.facebook.com/plugins/likebox.php?href=https%3A%2F%2Fwww.facebook.com%2FCodeForSeattle&amp;width&amp;height=62&amp;colorscheme=light&amp;show_faces=false&amp;header=false&amp;stream=false&amp;show_border=false&amp;appId=1403685376571754" scrolling="no" frameborder="0" style="border:none; overflow:hidden; height:62px;" allowTransparency="true"></iframe>
+      <p style="text-align: center; margin-bottom:0px;"><a href="https://twitter.com/open_seattle" class="twitter-follow-button" data-show-count="false" data-lang="en">Follow @open_seattle</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script></p>
+      <iframe src="//www.facebook.com/plugins/likebox.php?href=https%3A%2F%2Fwww.facebook.com%2FOpenSeattle&amp;width&amp;height=62&amp;colorscheme=light&amp;show_faces=false&amp;header=false&amp;stream=false&amp;show_border=false&amp;appId=1403685376571754" scrolling="no" frameborder="0" style="border:none; overflow:hidden; height:62px;" allowTransparency="true"></iframe>
     </div>
   </header>
 

--- a/_posts/2014-03-05-codeacross-roundup.md
+++ b/_posts/2014-03-05-codeacross-roundup.md
@@ -93,13 +93,13 @@ Sourcing and aggregating stolen bike data for Seattle, with a particular focus o
 
 It's not easy to get a sense of the impact of the proposed Metro bus cuts, so a team created a visualization to make that easier.
 
-[![Screenshot of metro cuts map](https://lh5.googleusercontent.com/-YcWNYJ6s2Mg/UwvVW9uQBmI/AAAAAAAABe4/CQ9sPYxJD2g/w954-h511-no/Screen+Shot+2014-02-24+at+3.25.24+PM.png)](http://codeforseattle.org/metrocuts)
+[![Screenshot of metro cuts map](https://lh5.googleusercontent.com/-YcWNYJ6s2Mg/UwvVW9uQBmI/AAAAAAAABe4/CQ9sPYxJD2g/w954-h511-no/Screen+Shot+2014-02-24+at+3.25.24+PM.png)](http://openseattle.org/metrocuts)
 
 ### Check out the live site:
-[http://codeforseattle.org/metrocuts](http://codeforseattle.org/metrocuts)
+[http://openseattle.org/metrocuts](http://openseattle.org/metrocuts)
 
 ### GitHub repository:
-[http://github.com/codeforseattle/metrocuts](http://github.com/codeforseattle/metrocuts)
+[http://github.com/openseattle/metrocuts](http://github.com/openseattle/metrocuts)
 
 ## Real-time bus locations
 
@@ -134,7 +134,7 @@ Wouldn't it be great if we had icons for the neighborhoods, landmarks, city serv
 - Provide the icon access via local channels to the community both on and offline, so that all members regardless of access or knowledge of technology may be aware or make use of icons.
 
 ### Github repo for project:
-[http://github.com/codeforseattle/seattle-icons](http://github.com/codeforseattle/seattle-icons)
+[http://github.com/openseattle/seattle-icons](http://github.com/openseattle/seattle-icons)
 
 ## Rate your internet: Open Broadbrand Performance Survey (BPS)
 
@@ -255,4 +255,4 @@ We got some awesome cookies from The Cookie Department! Learn more about them he
 
 ## Have anything to add?
 
-You can [edit this post on GitHub](https://github.com/codeforseattle/codeforseattle.github.com/blob/master/_posts/2014-03-05-codeacross-roundup.md) if we missed anything!
+You can [edit this post on GitHub](https://github.com/openseattle/openseattle.github.io/blob/master/_posts/2014-03-05-codeacross-roundup.md) if we missed anything!

--- a/_posts/2014-06-05-hack-for-change-seattle-2014.md
+++ b/_posts/2014-06-05-hack-for-change-seattle-2014.md
@@ -9,7 +9,7 @@ image_credit: "Will Scott"
 image_credit_url: "https://plus.google.com/photos/+WillScottName/albums/6020171987030870993"
 ---
 
-On May 31 Code for Seattle participated in the National Day of Civic Hacking with the local event Hack for Change Seattle.
+On May 31 Open Seattle participated in the National Day of Civic Hacking with the local event Hack for Change Seattle.
 
 About 60 participants worked on 10 projects ranging from air quality visualizations to hacking bicycle & pedestrian counters.
 
@@ -154,7 +154,7 @@ The OpenStreetMap team got two new volunteers set up and mapping.
 
 ## Editing SeattleWiki & working on LocalWiki API clients
 
-Seth Vincent added pages to [localwiki.net/seattle](http://localwiki.net/seattle), and made progress on the [JavaScript API client for LocalWiki](https://github.com/codeforseattle/node-localwiki-client).
+Seth Vincent added pages to [localwiki.net/seattle](http://localwiki.net/seattle), and made progress on the [JavaScript API client for LocalWiki](https://github.com/openseattle/node-localwiki-client).
 
 ## Intel gave people tablets!
 
@@ -171,4 +171,4 @@ _Photo by [Will Scott](https://plus.google.com/photos/+WillScottName/albums/6020
 The urban innovation award went to the Hacking Pedestrian and Bicycle counters team.
 
 ### This post is open source!
-Spot a typo or need to make additions to your team's description? [Find this post in the GitHub repo for this site](https://github.com/codeforseattle/codeforseattle.github.com/blob/master/_posts/2014-06-05-hack-for-change-seattle-2014.md).
+Spot a typo or need to make additions to your team's description? [Find this post in the GitHub repo for this site](https://github.com/openseattle/openseattle.github.io/blob/master/_posts/2014-06-05-hack-for-change-seattle-2014.md).

--- a/_posts/2014-07-30-new-to-civic-technology-code-for-seattle-project-ideas.md
+++ b/_posts/2014-07-30-new-to-civic-technology-code-for-seattle-project-ideas.md
@@ -1,5 +1,5 @@
 ---
-title: "New to civic technology & Code for Seattle? Here are some project ideas"
+title: "New to civic technology & Open Seattle? Here are some project ideas"
 slug: new-to-civic-technology-code-for-seattle-project-ideas
 published: true
 layout: page
@@ -82,4 +82,4 @@ Seattle is already added, but you can add other nearby cities.
 ### This post is open source!
 Spot a typo or have ideas for additional projects?
 
-[Edit this post in the GitHub repo for this site](https://github.com/codeforseattle/codeforseattle.github.com/blob/master/_posts/2014-07-30-new-to-civic-technology-code-for-seattle-project-ideas.md).
+[Edit this post in the GitHub repo for this site](https://github.com/openseattle/openseattle.github.com/blob/master/_posts/2014-07-30-new-to-civic-technology-code-for-seattle-project-ideas.md).

--- a/_posts/2014-11-18-art-civics-code-roundup.md
+++ b/_posts/2014-11-18-art-civics-code-roundup.md
@@ -10,7 +10,7 @@ Here are the projects & activities from the day:
 
 ## Memory Lane
 
-![street view team](https://discuss.codeforseattle.org/uploads/default/39/27949a49baaab49a.JPG)
+![street view team](https://discuss.openseattle.org/uploads/default/39/27949a49baaab49a.JPG)
 
 Ethan Phelps-Goodman, Allie Sterling, Rob Middleton, and Paul Ort created a way to explore Seattle neighborhoods that show Google's StreetView from this year paired with their images from 7 years ago. It's interesting to see how things have changed even just over the last 7 years. 
 
@@ -22,13 +22,13 @@ The code is on GitHub: [github.com/ethanpg/memory-lane](https://github.com/ethan
 
 ## Frye comments
 
-![](https://discuss.codeforseattle.org/uploads/default/40/02f7117a57c50d71.JPG)
+![](https://discuss.openseattle.org/uploads/default/40/02f7117a57c50d71.JPG)
 
 Josh Peterson & team worked on various ways of analyzing and visualizing comments from the Frye Museum's _#SocialMedium_ exhibit. [Here is one of the visualizations created by Eric Valpey](https://public.tableausoftware.com/profile/valpey#!/vizhome/FryeComments/FryeComments). 
 
 ## Ambient, physical visualization of crime
 
-![](https://discuss.codeforseattle.org/uploads/default/41/02a420c55676c1aa.JPG)
+![](https://discuss.openseattle.org/uploads/default/41/02a420c55676c1aa.JPG)
 
 Shelly Farnham's project used an arduino and [nearly-realtime crime data](https://data.seattle.gov/browse?category=Public+Safety) to create a visualization that doesn't require looking at a computer screen.
 
@@ -40,7 +40,7 @@ Mike Wheaton, Christina Montilla, & Wendy Call planned and mocked up Seward Park
 
 ## Explore.js
 
-![](https://discuss.codeforseattle.org/uploads/default/42/281f8fbf557cb394.JPG)
+![](https://discuss.openseattle.org/uploads/default/42/281f8fbf557cb394.JPG)
 
 Harini K and Seth Vincent worked on explore.js, a prototype of an open-source tool for making maps of artwalk locations.
 
@@ -58,7 +58,7 @@ Ann Summy & Igor Talpalatski worked on uploading and tagging public art location
 
 ## Maptime office hours
 
-![](https://discuss.codeforseattle.org/uploads/default/43/8db4218c5b6fc695.JPG)
+![](https://discuss.openseattle.org/uploads/default/43/8db4218c5b6fc695.JPG)
 
 Sam Matthews and Clifford Snow held Maptime "office hours," making themselves available to help anyone wanting to learn how to make online maps.
 
@@ -73,4 +73,4 @@ See more photos of the event here:
 ### This post is open source!
 Spot a typo or have ideas for additional projects?
 
-[Edit this post in the GitHub repo for this site](https://github.com/codeforseattle/codeforseattle.github.com/blob/master/_posts/2014-11-18-art-civics-code-roundup.md).
+[Edit this post in the GitHub repo for this site](https://github.com/openseattle/openseattle.github.io/blob/master/_posts/2014-11-18-art-civics-code-roundup.md).

--- a/_posts/2015-02-21-open-data-day.md
+++ b/_posts/2015-02-21-open-data-day.md
@@ -21,7 +21,7 @@ Break out session discussed datasets and where to get them, what "open data" rea
 
 ![post lunch](https://lh3.googleusercontent.com/-CUOZLSAA_Mo/VOvZY2RDkjI/AAAAAAAACp8/LMusyPqBqj0/w765-h510-no/_MG_4522.JPG)
 
-Organized by Code for Seattle, co-sponsored by Socrata, Microsoft, and UW CSE. 
+Organized by Open Seattle, co-sponsored by Socrata, Microsoft, and UW CSE. 
 
 ![Logan Franken](http://i1383.photobucket.com/albums/ah286/stinaseattle/Open%20data%20day_zpseo8oq1iv.jpg)
 

--- a/_posts/2015-04-07-whats-my-wage.md
+++ b/_posts/2015-04-07-whats-my-wage.md
@@ -4,7 +4,7 @@ published: true
 layout: page
 description:  Navigate Seattle's new minimum wage law with website and web app built by CfS team.
 ---
-In early February, Anna Minard of [Working Washington](http://www.workingwa.org/) arrived at Code for Seattle with an idea for a calculator to help workers determine their minimum age under the new minimum wage ordinance. Effective  April 1st, employers in Seattle must increase their employees' minimum wage over a four-year period until it reaches $15/hr.
+In early February, Anna Minard of [Working Washington](http://www.workingwa.org/) arrived at Open Seattle with an idea for a calculator to help workers determine their minimum age under the new minimum wage ordinance. Effective  April 1st, employers in Seattle must increase their employees' minimum wage over a four-year period until it reaches $15/hr.
 However, employees across the city may see the phase-in of $15 at a different scale and rate depending on the size of their employer and what benefits the employer offers.
 
 "We wanted workers to know which category they were in so they would know whether they were being paid the correct minimum wage—and have an easy way to report it if they thought they weren't getting what they're owed," says Minard.

--- a/_posts/2015-06-02-discotech-activities.md
+++ b/_posts/2015-06-02-discotech-activities.md
@@ -9,7 +9,7 @@ The Seattle DiscoTech is this weekend! The free event is part of the National Da
 
 There are two main types of activities at this event: learning about civic tech at an assortment of workshops, & checking out civic tech projects & organizations at the civic tech fair.
 
-**You can RSVP (for free) here: [http://www.meetup.com/Code-for-Seattle/events/222381787/](http://www.meetup.com/Code-for-Seattle/events/222381787/)**
+**You can RSVP (for free) here: [http://www.meetup.com/openseattle/events/222381787/](http://www.meetup.com/openseattle/events/222381787/)**
 
 ## Workshops
 
@@ -58,7 +58,7 @@ LocalWiki is a grassroots effort to collect, share, and open the world's local k
 - [Access Map ](http://www.accessmapseattle.com/)
 - [Upgrade Seattle](http://www.upgradeseattle.com/)
 - [Big-Brained Superheros](http://www.bigbrainedsuperheroes.org/)
-- [SEANetMap](https://github.com/codeforseattle/seanetmap)
+- [SEANetMap](https://github.com/openseattle/seanetmap)
 
 ## Schedule
 
@@ -71,5 +71,5 @@ LocalWiki is a grassroots effort to collect, share, and open the world's local k
 - **3:00 p.m.** – happy hour / civic tech project fair
 - **3:30 p.m.** – closing speaker: Candace Faber, organizer of Hack the Commute
 
-**You can RSVP (for free) here: [http://www.meetup.com/Code-for-Seattle/events/222381787/](http://www.meetup.com/Code-for-Seattle/events/222381787/)**
+**You can RSVP (for free) here: [http://www.meetup.com/openseattle/events/222381787/](http://www.meetup.com/openseattle/events/222381787/)**
 

--- a/about/index.md
+++ b/about/index.md
@@ -1,33 +1,33 @@
 ---
 layout: page
-title: About Code for Seattle
+title: About Open Seattle
 ---
 
 
 ## Who we are.
 
-We welcome anyone who is interested in using technology to make civic improvements.  Artists, writers, entrepreneurs, leaders, creative thinkers, and coders are invited to civic hacking nights and other events hosted by Code for Seattle.
+We welcome anyone who is interested in using technology to make civic improvements.  Artists, writers, entrepreneurs, leaders, creative thinkers, and coders are invited to civic hacking nights and other events hosted by Open Seattle.
 
 ## What we do.
 
-Code for Seattle runs a weekly civic hacking night, as well as hackathons and other events focused on building the civic technology community in Seattle and building prototype solutions for local civic issues.
+Open Seattle runs a weekly civic hacking night, as well as hackathons and other events focused on building the civic technology community in Seattle and building prototype solutions for local civic issues.
 
 ### Join our meetup group to get event announcements
 
 On our meetup group we announce the weekly civic hacking nights, hackathons, and other events.
 
-<a href="http://meetup.com/code-for-seattle" class="button" target="_blank">Join the CfS meetup group</a>
+<a href="http://meetup.com/openseattle" class="button" target="_blank">Join the CfS meetup group</a>
 <hr>
 
 ## Projects
 
-Join the Code for Seattle email newsletter to get updates about our projects. Emails are sent at most once a week, and provide a look at what's new with CfS.
+Join the Open Seattle email newsletter to get updates about our projects. Emails are sent at most once a week, and provide a look at what's new with CfS.
 
 {% include newsletter.html %}
 <hr>
 
-## Code for Seattle is a "brigade" of Code for America
+## Open Seattle is a "brigade" of Code for America
 
 We are a <a href="http://brigade.codeforamerica.org/">Code for America Brigade</a>, which means we're a group of Seattleites that contribute our talents towards improving the way our local governments and community organizations use the web. 
 
-Code for Seattle is about action and you're here because you are someone who takes action. <a href="http://brigade.codeforamerica.org/pages/activities">See what kind of things brigades do</a>, or <a href="http://codeforamerica.org/2012/03/08/jennifer-pahlka-at-ted-video/">watch this inspirational TED talk given by Jennifer Pahlka, the founder of Code for America.</a></p>
+Open Seattle is about action and you're here because you are someone who takes action. <a href="http://brigade.codeforamerica.org/pages/activities">See what kind of things brigades do</a>, or <a href="http://codeforamerica.org/2012/03/08/jennifer-pahlka-at-ted-video/">watch this inspirational TED talk given by Jennifer Pahlka, the founder of Code for America.</a></p>

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "openseattle.github.com",
+  "name": "openseattle.github.io",
   "version": "0.0.0",
   "dependencies": {
     "html5shiv": "~3.6.2",

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "codeforseattle.github.com",
+  "name": "openseattle.github.com",
   "version": "0.0.0",
   "dependencies": {
     "html5shiv": "~3.6.2",

--- a/code-across/index.html
+++ b/code-across/index.html
@@ -4,7 +4,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>CodeAcross Seattle | Code for Seattle</title>
+    <title>CodeAcross Seattle | Open Seattle</title>
     <meta name="description" content="A Seattle, WA event for CodeAcross and International Open Data Day. CodeAcross Seattle, on February 22, is a full day of events for incubating civic innovation in our city. We’re bringing together local governments, businesses, schools, and community organizations, as well as social service organizations, media outlets, foundations, and the public to collaborate on civic innovation that will help our residents and improve our region.">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -32,8 +32,8 @@
       <ul class="main">
         <li><a href="/#meetups">Events</a></li>
         <li><a href="/#projects">Projects</a></li>
-        <li><a href="http://codeforseattle.tumblr.com" target="_blank">Blog</a></li>
-        <li><a href="https://github.com/codeforseattle" target="_blank">GitHub</a></li>
+        <li><a href="http://openseattle.tumblr.com" target="_blank">Blog</a></li>
+        <li><a href="https://github.com/openseattle" target="_blank">GitHub</a></li>
         <li><a href="/#contact">Contact</a></li>
       </ul>
     </div>
@@ -55,7 +55,7 @@
   <div class="container">
     <div class="inner-wrapper">
       <img src="/images/code-across/codeacross2.jpg" class="full">
-			<p><a class="button red register-button" href="http://www.meetup.com/Code-for-Seattle/events/162078952/">Register for CodeAcross Seattle on Meetup.com</a></p>
+			<p><a class="button red register-button" href="http://www.meetup.com/openseattle/events/162078952/">Register for CodeAcross Seattle on Meetup.com</a></p>
 
 			<h4><b>CodeAcross Seattle, on February 22, is a full day of events for incubating civic innovation in our city.</b></h4> 
 			<h4>We’re bringing together local governments, businesses, schools, and community organizations, as well as social service organizations, media outlets, foundations, and the public to collaborate on civic innovation that will help our residents and improve our region.</h4>
@@ -97,9 +97,9 @@
       <a name="what-to-work-on"></a>
 			<h2 id="what-to-work-on">What will people be working on?</h2>
 
-      <p><b><a href="https://codeforseattle.hackpad.com/CodeAcross-Seattle" target="blank">See this hackpad for all projects we'll work on & add your own!</a></b></p>
+      <p><b><a href="https://openseattle.hackpad.com/CodeAcross-Seattle" target="blank">See this hackpad for all projects we'll work on & add your own!</a></b></p>
 
-      <p>Many in-progress Code For Seattle projects will be available for you to work on: contribute to <a href="http://seattlewiki.net">the Seattle Wiki</a>, finish <a href="http://seattlefoodtrucks.herokuapp.com">a map of local food trucks</a>, work on <a href="http://github.com/willscott/geosub">a location-based event notification service</a>, contribute to <a href="http://openstreetmap.org">OpenStreetMap</a>... the list goes on and on.</p>
+      <p>Many in-progress Open Seattle projects will be available for you to work on: contribute to <a href="http://seattlewiki.net">the Seattle Wiki</a>, finish <a href="http://seattlefoodtrucks.herokuapp.com">a map of local food trucks</a>, work on <a href="http://github.com/willscott/geosub">a location-based event notification service</a>, contribute to <a href="http://openstreetmap.org">OpenStreetMap</a>... the list goes on and on.</p>
       <p>Code For America has also issued a list of challenges for local communities to tackle this year:</p>
       <ul>
         <li>
@@ -124,8 +124,8 @@
 
       <a name="sponsorship"></a>
 			<h2 id="sponsor">Sponsor CodeAcross Seattle</h2>
-      <p>We are grateful you are considering supporting our event. Code Across Seattle is a 100% volunteer driven event put on by Code for Seattle. <b>We need your support. Please email us at <a href="mailto:svincent@codeforamerica.org">svincent@codeforamerica.org</a> or <a href="mailto:wscott@codeforamerica.org">wscott@codeforamerica.org</a> if you can help!</b>
-			<p>We are seeking donations of cash, venue, goods, prizes, and services. The easiest way to support Code Across Seattle is to make a cash contribution by check or our web site (link below). Code for Seattle is our local arm of the national organization Code for America. As a 501(c)(3) nonprofit and nonpartisan organization, donations to Code for America (and our event) are tax deductible. All contributors who desire it will receive recognition through event marketing.</p>
+      <p>We are grateful you are considering supporting our event. Code Across Seattle is a 100% volunteer driven event put on by Open Seattle. <b>We need your support. Please email us at <a href="mailto:svincent@codeforamerica.org">svincent@codeforamerica.org</a> or <a href="mailto:wscott@codeforamerica.org">wscott@codeforamerica.org</a> if you can help!</b>
+			<p>We are seeking donations of cash, venue, goods, prizes, and services. The easiest way to support Code Across Seattle is to make a cash contribution by check or our web site (link below). Open Seattle is our local arm of the national organization Code for America. As a 501(c)(3) nonprofit and nonpartisan organization, donations to Code for America (and our event) are tax deductible. All contributors who desire it will receive recognition through event marketing.</p>
 
 			<p><a href="http://codeforamerica.org/donate" class="button red" target="blank">Donate through CodeForAmerica.org</a></p>
 
@@ -134,7 +134,7 @@
 			<h2>Why you should sponsor CodeAcross Seattle</h2>
 			<p>Because, like us, you want to help make Seattle better, together. We’re recruiting extensively from local governments, businesses, schools, communities, as well as social service organizations, media outlets, foundations, and the public. We want to bring these diverse communities together to take on civic innovation challenges that will help our residents and improve our region.</p>
 
-			<p><a class="button red register-button" href="http://www.meetup.com/Code-for-Seattle/events/162078952/">Register for CodeAcross Seattle on Meetup.com</a></p>
+			<p><a class="button red register-button" href="http://www.meetup.com/openseattle/events/162078952/">Register for CodeAcross Seattle on Meetup.com</a></p>
 
       <h2 id="sponsors">Partners & Sponsors</h2>
       <p style="display:block;"><img src="{{baseurl}}/images/code-across/sponsors/cfa.png" style="width:100px;height:auto; margin-right: 10px;"><img src="{{baseurl}}/images/code-across/sponsors/sunlight.jpg" style="width:100px;height:auto; margin-right: 10px;"><img src="{{baseurl}}/images/code-across/sponsors/okfn.jpg" style="width:100px;height:auto; margin-right: 10px;"></p>

--- a/code-of-conduct/index.md
+++ b/code-of-conduct/index.md
@@ -4,9 +4,9 @@ slug: code-of-conduct
 layout: page
 ---
 
-Code for Seattle activities and events should foster meaningful collaboration between participants, community partners, and government partners.
+Open Seattle activities and events should foster meaningful collaboration between participants, community partners, and government partners.
 
-The Code for Seattle community expects that Code for Seattle activities and events:
+The Open Seattle community expects that Open Seattle activities and events:
 
 - Are a safe and respectful environment for all participants.
 - Are a place where people are free to fully express their identities.
@@ -20,7 +20,7 @@ The Code for Seattle community expects that Code for Seattle activities and even
 - Actively involve community groups and those with subject matter expertise in the decision-making process.
 - Ensure that the relationships and conversations between community members, the local government staff and community partners remain respectful, participatory, and productive.
 
-Code for Seattle reserves the right to ask anyone in violation of these policies not to participate in Code for Seattle events or network activities.
+Open Seattle reserves the right to ask anyone in violation of these policies not to participate in Open Seattle events or network activities.
 
 #### Anti-Harassment Policy
 
@@ -30,19 +30,19 @@ This policy is based on several other policies, including the Ohio LinuxFest ant
 
 * * * 
 
-All Code for Seattle events and their staff, presenters, and participants are held to an anti-harassment policy, included below.
+All Open Seattle events and their staff, presenters, and participants are held to an anti-harassment policy, included below.
 
-Code for Seattle is dedicated to providing a harassment-free experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. We do not tolerate harassment of staff, presenters, and participants in any form. Sexual language and imagery is not appropriate for any Code for Seattle event or network activity, including talks. Anyone in violation of these policies may expelled from Code for Seattle events or network activities, at the discretion of the event organizers.
+Open Seattle is dedicated to providing a harassment-free experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. We do not tolerate harassment of staff, presenters, and participants in any form. Sexual language and imagery is not appropriate for any Open Seattle event or network activity, including talks. Anyone in violation of these policies may expelled from Open Seattle events or network activities, at the discretion of the event organizers.
 
 Harassment includes but is not limited to: offensive verbal or written comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion; sexual images in public spaces; deliberate intimidation; stalking; following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact; unwelcome sexual attention; unwarranted exclusion; and patronizing language or action.
 
-If a participant engages in harassing behavior, the event organizers may take any action they deem appropriate, including warning the offender or expulsion from Code for Seattle events and activities. 
+If a participant engages in harassing behavior, the event organizers may take any action they deem appropriate, including warning the offender or expulsion from Open Seattle events and activities. 
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the event staff immediately. You can contact Seth Vincent at svincent@codeforamerica.org & 360.850.9700 or Will Scott at wscott@codeforamerica.org & 206.395.9362. Event staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event.
 
 If you cannot reach an event organizer and/or it is an emergency, please call 911 and/or remove yourself from the situation. 
 
-You can also contact Code for America about harassment at safespace@codeforamerica.org and feel free to use the email template below. Code for Seattle & Code for America staff acknowledge that we are not always in a position to evaluate a given situation due to the number of events and the fact that our team is not always present. However, we are hopeful that by providing these guidelines we are establishing a community that jointly adheres to these values and can provide an environment that is welcoming to all.
+You can also contact Code for America about harassment at safespace@codeforamerica.org and feel free to use the email template below. Open Seattle & Code for America staff acknowledge that we are not always in a position to evaluate a given situation due to the number of events and the fact that our team is not always present. However, we are hopeful that by providing these guidelines we are establishing a community that jointly adheres to these values and can provide an environment that is welcoming to all.
 
 We value your attendance and hope that by communicating these expectations widely we can all enjoy a harassment-free environment.
 

--- a/contact/index.md
+++ b/contact/index.md
@@ -3,13 +3,13 @@ layout: page
 title: "Contact us to learn more about CfS"
 ---
 
-## Email the organizers of Code for Seattle:
+## Email the organizers of Open Seattle:
 - **Seth Vincent** – svincent@codeforamerica.org
 - **Will Scott** – wscott@codeforamerica.org
 
 
 ## Find us around the interwebs:
-- **GitHub:** [github.com/codeforseattle](https://github.com/codeforseattle)
-- **Twitter:** <a href="http://twitter.com/code4seattle" target="_blank">@code4seattle</a>
-- **Facebook:** <a href="https://www.facebook.com/CodeForSeattle" target="_blank">facebook.com/CodeForSeattle</a>
-- **Tumblr:** <a href="http://codeforseattle.tumblr.com" target="_blank">codeforseattle.tumblr.com</a>
+- **GitHub:** [github.com/OpenSeattle](https://github.com/openseattle)
+- **Twitter:** <a href="http://twitter.com/open_seattle" target="_blank">@open_seattle</a>
+- **Facebook:** <a href="https://www.facebook.com/OpenSeattle" target="_blank">facebook.com/OpenSeattle</a>
+- **Tumblr:** <a href="http://openseattle.tumblr.com" target="_blank">openseattle.tumblr.com</a>

--- a/events/april-2-2015/body.md
+++ b/events/april-2-2015/body.md
@@ -1,5 +1,5 @@
 
-![](http://media.tumblr.com/56084e738f4f07b6ade8d68d940c3dab/tumblr_inline_mz1zq8NrXb1rs4nv6.gif) welcome to code for seattle
+![](http://media.tumblr.com/56084e738f4f07b6ade8d68d940c3dab/tumblr_inline_mz1zq8NrXb1rs4nv6.gif) welcome to open seattle
 
 ![](http://stream1.gifsoup.com/view/62348/traffic-o.gif) hack the commute was really great
 

--- a/events/index.md
+++ b/events/index.md
@@ -3,19 +3,19 @@ layout: page
 title: CfS Events
 ---
 
-This is a list of events organized by Code for Seattle & the events of other organizations that are relevant to civic engagement & technology.
+This is a list of events organized by Open Seattle & the events of other organizations that are relevant to civic engagement & technology.
 
 ## Weekly meetups
 
-We meet every Thursday at various places around town. Get all the details at our meetup group: [http://meetup.com/code-for-seattle](http://meetup.com/code-for-seattle)
+We meet every Thursday at various places around town. Get all the details at our meetup group: [http://meetup.com/openseattle](http://meetup.com/openseattle)
 
 ## Upcoming events
 
 ### June 17, Municipal Broadband Lunch and Learn at Impact Hub Seattle, 12pm
 
-RSVP:  [http://www.meetup.com/Code-for-Seattle/events/222977485/](http://www.meetup.com/Code-for-Seattle/events/222977485/)
+RSVP:  [http://www.meetup.com/openseattle/events/222977485/](http://www.meetup.com/openseattle/events/222977485/)
 
-Christopher Mitchell is a national expert on community networks and approaches, having authored the most in-depth case studies of how a variety of communities have already moved forward on municipal networks. He'll address anything from why local governments have to get in the game to which technologies are most appropriate where. Hosted by Upgrade Seattle in partnership with Code for Seattle.
+Christopher Mitchell is a national expert on community networks and approaches, having authored the most in-depth case studies of how a variety of communities have already moved forward on municipal networks. He'll address anything from why local governments have to get in the game to which technologies are most appropriate where. Hosted by Upgrade Seattle in partnership with Open Seattle.
 
 Make sure to RSVP here: [http://impacthubmunicipalbroadband.brownpapertickets.com/](http://impacthubmunicipalbroadband.brownpapertickets.com/)
 
@@ -23,7 +23,7 @@ More on Mitchell: [http://muninetworks.org/users/christopher](http://muninetwork
 
 ### June 18,  Upgrade Seattle Launch  at Seattle Town Hall, 7pm
 
-RSVP : [http://www.meetup.com/Code-for-Seattle/events/222977540/](http://www.meetup.com/Code-for-Seattle/events/222977540/)
+RSVP : [http://www.meetup.com/openseattle/events/222977540/](http://www.meetup.com/openseattle/events/222977540/)
 
 Upgrade Seattle–a grassroots group of community organizers, artists, tech workers, and others–is calling for a city-owned alternative to the for-profit internet providers in the Puget Sound. Christopher Mitchell, Director of the Community Broadband Networks Initiative with the Institute for Local Self-Reliance, local activist/musician Hollis Wong-Wear, and other community members will lead a discussion on the current push for city-owned internet and its broader implications for the community. The discussion will be followed by breakout sessions where attendees can get involved in organizing for better broadband.
 
@@ -33,7 +33,7 @@ More on Upgrade Seattle: [http://upgradeseattle.com](http://townhallseattle.org/
 
 ### June 26-28, Electric Sky: An Art and Tech Weekend Campathon, 10am
 
-RSVP: http://www.meetup.com/Code-for-Seattle/events/222382371/
+RSVP: http://www.meetup.com/openseattle/events/222382371/
 
 You must register at http://ElectricSkyArtCamp.com
 
@@ -46,6 +46,6 @@ Please join us for Electric Sky, an art and tech weekend campathon bringing toge
 
 <h2>Join our meetup group to get event announcements</h2>
 <p>On our meetup group we announce the weekly civic hacking nights, hackathons, and other events.</p>
-<p><a href="http://meetup.com/code-for-seattle" class="button" target="_blank">Join the CfS meetup group</a></p>
+<p><a href="http://meetup.com/openseattle" class="button" target="_blank">Join the CfS meetup group</a></p>
 
 

--- a/guides/creating-posts.md
+++ b/guides/creating-posts.md
@@ -1,20 +1,20 @@
 ---
 layout: page
-title: "Creating posts on codeforseattle.org"
+title: "Creating posts on openseattle.org"
 ---
 
-The Code for Seattle website is hosted on [GitHub pages](https://pages.github.com/) and uses [Jekyll, a static site generator](http://jekyllrb.com/).
+The Open Seattle website is hosted on [GitHub pages](https://pages.github.com/) and uses [Jekyll, a static site generator](http://jekyllrb.com/).
 
-You can create a post on codeforseattle.org in two ways:
+You can create a post on openseattle.org in two ways:
 
 - through GitHub.com
 - on your computer using git
 
 To get started, you'll need to fork the website repository on GitHub.
 
-## Forking codeforseattle.github.com
+## Forking openseattle.github.io
 
-Go to [github.com/codeforseattle/codeforseattle.github.com](https://github.com/codeforseattle/codeforseattle.github.com) and click the "Fork" button.
+Go to [github.com/openseattle/openseattle.github.io](https://github.com/openseattle/openseattle.github.io) and click the "Fork" button.
 
 ## Making changes on GitHub.com
 
@@ -52,7 +52,7 @@ layout: page
 
 Make sure to set published to `true` when you're ready to make the post go live.
 
-[Take a look at this post as an example.](https://github.com/codeforseattle/codeforseattle.github.com/blob/master/_posts/2014-11-18-art-civics-code-roundup.md)
+[Take a look at this post as an example.](https://github.com/openseattle/openseattle.github.io/blob/master/_posts/2014-11-18-art-civics-code-roundup.md)
 
 ### Markdown
 
@@ -68,7 +68,7 @@ On some pages it's collapsed, so all you'll see is the little icon.
 
 ### Click 'New Pull Request'
 
-Make sure to create a pull request to submit the changes in your repository to the codeforseattle.org/codeforseattle.github.com repository.
+Make sure to create a pull request to submit the changes in your repository to the openseattle/openseattle.github.io repository.
 
 ---
 

--- a/guides/index.md
+++ b/guides/index.md
@@ -3,12 +3,12 @@ layout: page
 title: Guides
 ---
 
-These guides are documentation to running various aspects of Code for Seattle as well as running civic tech projects in general.
+These guides are documentation to running various aspects of Open Seattle as well as running civic tech projects in general.
 
-It's just getting started! You can help! These guides are part of the codeforseattle.org repository on GitHub.
+It's just getting started! You can help! These guides are part of the openseattle.org repository on GitHub.
 
 
 ## Guides:
-- [Getting oriented to Code for Seattle](/orientation)
-- [Creating posts on codeforseattle.org](/guides/creating-posts)
+- [Getting oriented to Open Seattle](/orientation)
+- [Creating posts on openseattle.org](/guides/creating-posts)
 - [Adding a project to our projects list](/guides/project-list)

--- a/guides/orientation.md
+++ b/guides/orientation.md
@@ -4,18 +4,17 @@ title: "Orientation"
 permalink: /orientation/
 ---
 
-Welcome to Code for Seattle!
+Welcome to Open Seattle!
 
 ### To get started, you should do these things:
 
-- Check out all the different Code for Seattle websites, social media, etc:
-  - [twitter](http://twitter.com/code4seattle)
-  - [github](http://github.com/codeforseattle)
-  - [facebook](https://www.facebook.com/CodeForSeattle)
-  - [mailing list](http://codeforseattle.us3.list-manage2.com/subscribe/?u=f405e5b88dbe4706a8854768b&id=d0d6ff42a4)
-  - [discussion forum](http://discuss.codeforseattle.org)
-  - [meetup group](http://meetup.com/code-for-seattle)
-  - irc: #codeforseattle on freenode
+- Check out all the different Open Seattle websites, social media, etc:
+  - [twitter](http://twitter.com/open_seattle)
+  - [github](http://github.com/openseattle)
+  - [facebook](https://www.facebook.com/OpenSeattle)
+  - [mailing list](http://openseattle.us3.list-manage2.com/subscribe/?u=f405e5b88dbe4706a8854768b&id=d0d6ff42a4)
+  - [discussion forum](http://discuss.openseattle.org)
+  - [meetup group](http://meetup.com/openseattle)
 - Take a look through the [list of projects](/projects)
 - Fill out the following orientation form so we can learn more about you and help match you with ongoing projects & other members:
 

--- a/guides/project-list.md
+++ b/guides/project-list.md
@@ -5,16 +5,16 @@ title: "Adding a project to our project list"
 
 To add a project to the project list, follow these instructions:
 
-You can edit the project list on codeforseattle.org in two ways:
+You can edit the project list on openseattle.org in two ways:
 
 - through GitHub.com
 - on your computer using git
 
 To get started, you'll need to fork the website repository on GitHub.
 
-## Forking codeforseattle.github.com
+## Forking openseattle.github.io
 
-Go to [github.com/codeforseattle/codeforseattle.github.com](https://github.com/codeforseattle/codeforseattle.github.com) and click the "Fork" button.
+Go to [github.com/openseattle/openseattle.github.io](https://github.com/openseattle/openseattle.github.io) and click the "Fork" button.
 
 ## Making changes on GitHub.com
 
@@ -28,10 +28,10 @@ For detailed guides to manipulating files through GitHub.com, go here: [help.git
 
 To add your project you will: 
 
-- Go to http://github.com/codeforseattle/codeforseattle.github.com
+- Go to http://github.com/openseattle/openseattle.github.io
 - Click the `_data` folder
 - Click the `projects.yml` file
-- Or go directly to that file with this url: https://github.com/codeforseattle/codeforseattle.github.com/blob/master/_data/projects.yml
+- Or go directly to that file with this url: https://github.com/openseattle/openseattle.github.io/blob/master/_data/projects.yml
 - Click the pencil icon in the file's toolbar to start editing
 - add your project, using this as a template:
   ```
@@ -58,7 +58,7 @@ On some pages it's collapsed, so all you'll see is the little icon.
 
 ### Click 'New Pull Request'
 
-Make sure to create a pull request to submit the changes in your repository to the codeforseattle.org/codeforseattle.github.com repository.
+Make sure to create a pull request to submit the changes in your repository to the openseattle.org/openseattle.github.io repository.
 
 ---
 

--- a/guides/project-list.md
+++ b/guides/project-list.md
@@ -58,7 +58,7 @@ On some pages it's collapsed, so all you'll see is the little icon.
 
 ### Click 'New Pull Request'
 
-Make sure to create a pull request to submit the changes in your repository to the openseattle.org/openseattle.github.io repository.
+Make sure to create a pull request to submit the changes in your repository to the openseattle/openseattle.github.io repository.
 
 ---
 

--- a/hackforchange/2013/index.html
+++ b/hackforchange/2013/index.html
@@ -36,8 +36,8 @@
       <ul class="main">
   <li><a href="/#meetups">Events</a></li>
   <li><a href="/#projects">Projects</a></li>
-  <li><a href="http://codeforseattle.tumblr.com" target="_blank">Blog</a></li>
-  <li><a href="https://github.com/codeforseattle" target="_blank">GitHub</a></li>
+  <li><a href="http://openseattle.tumblr.com" target="_blank">Blog</a></li>
+  <li><a href="https://github.com/openseattle" target="_blank">GitHub</a></li>
   <li><a href="/#contact">Contact</a></li>
 </ul>
     </div>

--- a/hackforchange/index.html
+++ b/hackforchange/index.html
@@ -36,8 +36,8 @@
       <ul class="main">
   <li><a href="/#meetups">Events</a></li>
   <li><a href="/#projects">Projects</a></li>
-  <li><a href="http://codeforseattle.tumblr.com" target="_blank">Blog</a></li>
-  <li><a href="https://github.com/codeforseattle" target="_blank">GitHub</a></li>
+  <li><a href="http://openseattle.tumblr.com" target="_blank">Blog</a></li>
+  <li><a href="https://github.com/openseattle" target="_blank">GitHub</a></li>
   <li><a href="/#contact">Contact</a></li>
 </ul>
     </div>
@@ -166,13 +166,13 @@
        data-0="transform:translate(0,-100%);"
        data-_needle="transform:translate(0,0%);">
        <div class="share" style="width:300px; padding-top:10px;">
-      <a class="icon-twitter" href="https://twitter.com/share?text=Join me at Hack for Change Seattle!&url=http://codeforseattle.org/hackforchange&hashtags=hackforchangeSEA"
+      <a class="icon-twitter" href="https://twitter.com/share?text=Join me at Hack for Change Seattle!&url=http://openseattle.org/hackforchange&hashtags=hackforchangeSEA"
           onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
           <span class="hidden">Twitter</span></a>
-      <a class="icon-facebook" href="https://www.facebook.com/sharer/sharer.php?u=http://codeforseattle.org/hackforchange"
+      <a class="icon-facebook" href="https://www.facebook.com/sharer/sharer.php?u=http://openseattle.org/hackforchange"
           onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
           <span class="hidden">Facebook</span></a>
-      <a class="icon-google-plus" href="https://plus.google.com/share?url=http://codeforseattle.org/hackforchange"
+      <a class="icon-google-plus" href="https://plus.google.com/share?url=http://openseattle.org/hackforchange"
          onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
           <span class="hidden">Google+</span></a>
         </div>
@@ -180,7 +180,7 @@
 
   <div class="container">
     <br>
-    <a href='http://www.meetup.com/Code-for-Seattle/events/175917132/'
+    <a href='http://www.meetup.com/openseattle/events/175917132/'
        class='signup'>
        <span>
       Sign up free on
@@ -208,13 +208,13 @@
 
     <div class="share">
       <h4>Share Hack for Change Seattle:</h4>
-      <a class="icon-twitter" href="https://twitter.com/share?text=Join me at Hack for Change Seattle!&url=http://codeforseattle.org/hackforchange&hashtags=hackforchangeSEA"
+      <a class="icon-twitter" href="https://twitter.com/share?text=Join me at Hack for Change Seattle!&url=http://openseattle.org/hackforchange&hashtags=hackforchangeSEA"
           onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
           <span class="hidden">Twitter</span></a>
-      <a class="icon-facebook" href="https://www.facebook.com/sharer/sharer.php?u=http://codeforseattle.org/hackforchange"
+      <a class="icon-facebook" href="https://www.facebook.com/sharer/sharer.php?u=http://openseattle.org/hackforchange"
           onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
           <span class="hidden">Facebook</span></a>
-      <a class="icon-google-plus" href="https://plus.google.com/share?url=http://codeforseattle.org/hackforchange"
+      <a class="icon-google-plus" href="https://plus.google.com/share?url=http://openseattle.org/hackforchange"
          onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
           <span class="hidden">Google+</span></a>
     <div>

--- a/index.html
+++ b/index.html
@@ -21,10 +21,10 @@ title: Civic technology in Seattle, WA
 <div style="text-align:center;">
 <h2>Join our meetup group to get event announcements</h2>
 <p>On our meetup group we announce the weekly civic hacking nights, <br>hackathons, and other events.</p>
-<p><a href="http://meetup.com/code-for-seattle" class="button" target="_blank">Join the CfS meetup group</a></p>
+<p><a href="http://meetup.com/openseattle" class="button" target="_blank">Join the CfS meetup group</a></p>
 
 <hr>
 <h2 style="margin-bottom:10px;">Get updates about our projects:</h2>
-<p>Join the Code for Seattle email newsletter to get updates about our projects. Emails are sent once a month, and provide a look at what's new with CfS.</p>
+<p>Join the Open Seattle email newsletter to get updates about our projects. Emails are sent once a month, and provide a look at what's new with CfS.</p>
 <div>{% include newsletter.html %}</div>
 </div>

--- a/open-data-day/index.html
+++ b/open-data-day/index.html
@@ -6,7 +6,7 @@ redirect_from: "/seattle-data-day/"
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Seattle Open Data Day | Code for Seattle</title>
+    <title>Seattle Open Data Day | Open Seattle</title>
     <meta name="description" content="A Seattle, WA event for International Open Data Day and CodeAcross. Seattle Open Data Day, on February 21, is an unconference for incubating civic innovation in our city.">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -93,7 +93,7 @@ redirect_from: "/seattle-data-day/"
       
       <p>Make sure to read our <a href="{{site.baseurl}}/code-of-conduct/">Code of Conduct</a>.</p>
       
-      <p><a class="button small" href="http://www.meetup.com/Code-for-Seattle/events/220166485/">Sign up for Seattle Open Data Day!</a></p>
+      <p><a class="button small" href="http://www.meetup.com/openseattle/events/220166485/">Sign up for Seattle Open Data Day!</a></p>
       
       <br>
       <h2 id="sessions">Sessions</h2>
@@ -173,7 +173,7 @@ redirect_from: "/seattle-data-day/"
       <h2 id="sponsors">Partners & Sponsors</h2>
       
       <div class="sponsor-logos">
-        <img src="http://codeforseattle.org/images/logo-300x300.png" style="width: 150px;">
+        <img src="http://openseattle.org/images/logo-300x300.png" style="width: 150px;">
         <img src="{{baseurl}}/images/open-data-day/CSElogo2_250.png" style="width: 150px;">
         <img src="{{baseurl}}/images/code-across/sponsors/microsoft.jpg">
         <img src="{{baseurl}}/images/code-across/sponsors/socrata.jpg">
@@ -182,8 +182,8 @@ redirect_from: "/seattle-data-day/"
       <hr>
       
       <h2 id="sponsorship">Sponsor Seattle Open Data Day</h2>
-      <p>We are grateful you are considering supporting our event. Seattle Data Day is a 100% volunteer driven event put on by Code for Seattle. <b>We need your support. Please email us at <a href="mailto:svincent@codeforamerica.org">svincent@codeforamerica.org</a> or <a href="mailto:wscott@codeforamerica.org">wscott@codeforamerica.org</a> if you can help!</b>
-      <p>We are seeking donations of cash, goods, and services. The easiest way to support Seattle Data Day is to make a cash contribution by check or  through our website (link below). Code for Seattle is our local arm of the national organization Code for America. As a 501(c)(3) nonprofit and nonpartisan organization, donations to Code for America (and our event) are tax deductible. All contributors who desire it will receive recognition through event marketing.</p>
+      <p>We are grateful you are considering supporting our event. Seattle Data Day is a 100% volunteer driven event put on by Open Seattle. <b>We need your support. Please email us at <a href="mailto:svincent@codeforamerica.org">svincent@codeforamerica.org</a> or <a href="mailto:wscott@codeforamerica.org">wscott@codeforamerica.org</a> if you can help!</b>
+      <p>We are seeking donations of cash, goods, and services. The easiest way to support Seattle Data Day is to make a cash contribution by check or  through our website (link below). Open Seattle is our local arm of the national organization Code for America. As a 501(c)(3) nonprofit and nonpartisan organization, donations to Code for America (and our event) are tax deductible. All contributors who desire it will receive recognition through event marketing.</p>
       
       <h3>Why you should sponsor Seattle Open Data Day</h3>
       <p>Because, like us, you want to help make Seattle better, together. We’re recruiting extensively from local governments, businesses, schools, communities, as well as social service organizations, media outlets, foundations, and the public. We want to bring these diverse communities together to take on civic innovation challenges that will help our residents and improve our region.</p>
@@ -191,7 +191,7 @@ redirect_from: "/seattle-data-day/"
       
       <p><a href="http://codeforamerica.org/donate" class="button red" target="blank">Donate through CodeForAmerica.org</a></p>
 
-      <p>Enter <b>Code for Seattle – Seattle Open Data Day</b> In the field for “What inspired your contribution?”</p>
+      <p>Enter <b>Open Seattle – Seattle Open Data Day</b> In the field for “What inspired your contribution?”</p>
 
       
 

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "codeforseattle.github.com",
+  "name": "openseattle.github.com",
   "version": "0.0.0",
-  "description": "This is the repo for codeforseattle.org.",
+  "description": "This is the repo for openseattle.org.",
   "main": "index.js",
   "scripts": {
     "start": "bundle exec jekyll serve --watch"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/codeforseattle/codeforseattle.github.com.git"
+    "url": "git://github.com/openseattle/openseattle.github.com.git"
   },
   "author": "sethvincent <sethvincent@gmail.com> (http://sethvincent.com/)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/codeforseattle/codeforseattle.github.com/issues"
+    "url": "https://github.com/openseattle/openseattle.github.com/issues"
   },
-  "homepage": "https://github.com/codeforseattle/codeforseattle.github.com"
+  "homepage": "https://github.com/openseattle/openseattle.github.com"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openseattle.github.com",
+  "name": "openseattle.github.io",
   "version": "0.0.0",
   "description": "This is the repo for openseattle.org.",
   "main": "index.js",
@@ -8,12 +8,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/openseattle/openseattle.github.com.git"
+    "url": "git://github.com/openseattle/openseattle.github.io.git"
   },
   "author": "sethvincent <sethvincent@gmail.com> (http://sethvincent.com/)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/openseattle/openseattle.github.com/issues"
+    "url": "https://github.com/openseattle/openseattle.github.io/issues"
   },
-  "homepage": "https://github.com/openseattle/openseattle.github.com"
+  "homepage": "https://github.com/openseattle/openseattle.github.io"
 }

--- a/partners/index.md
+++ b/partners/index.md
@@ -3,7 +3,7 @@ layout: page
 title: "CfS Partners"
 ---
 
-## Code for Seattle Government Partners:
+## Open Seattle Government Partners:
 
 We're priviledged to have worked in the past with individuals throughout
 the local city, county, and state government. We actively work with:
@@ -12,10 +12,10 @@ the local city, county, and state government. We actively work with:
 - **[Seattle Police Department]**
 
 
-## Code for Seattle Community Partners:
+## Open Seattle Community Partners:
 
 We're greatful for the ongoing support from a number of local community
-organizations. Without them, code for seattle would not be what it is today.
+organizations. Without them, Open Seattle would not be what it is today.
 
 - **[Socrata](http://socrata.com)** - They run data.seattle.gov, and many other open data portals!
 - **[Impact Hub Seattle](http://www.impacthubseattle.com/)** - A coworking space for social impact, they host many of our meetups.

--- a/plan/2015.md
+++ b/plan/2015.md
@@ -3,13 +3,13 @@ title: 2015 Strategic Plan
 layout: page
 ---
 
-_This is a work-in-progress plan for Code for Seattle's events & programs in 2015. You can contribute! Suggest edits to this page [via GitHub](https://github.com/codeforseattle/codeforseattle.github.com/blob/master/plan/2015.md)._
+_This is a work-in-progress plan for Open Seattle's events & programs in 2015. You can contribute! Suggest edits to this page [via GitHub](https://github.com/openseattle/openseattle.github.io/blob/master/plan/2015.md)._
 
 ---
 
 ## Who We Are
 
-Code for Seattle is a group of Seattle residents using technology to support civic engagement and improve our community.
+Open Seattle is a group of Seattle residents using technology to support civic engagement and improve our community.
 
 ### Core Leadership Team
 
@@ -49,13 +49,13 @@ Code for Seattle is a group of Seattle residents using technology to support civ
 
 #### Collaboration & partnerships
 
-One of the trends we see in Seattle this fall that we expect to continue through 2015 is an increasing willingness and interest on the part of government agencies to partner and run hackathons for issues and problems we're facing. We saw the first of these in the SPD hackathon on Police Video Recording in December, and the SPD has signalled interest in continuing a series of such events through 2015.  Partnering with individual departments to work on targeted issues appears to draw significant interest, and we see interest and opportunity for code for seattle to be involved in these events.
+One of the trends we see in Seattle this fall that we expect to continue through 2015 is an increasing willingness and interest on the part of government agencies to partner and run hackathons for issues and problems we're facing. We saw the first of these in the SPD hackathon on Police Video Recording in December, and the SPD has signalled interest in continuing a series of such events through 2015.  Partnering with individual departments to work on targeted issues appears to draw significant interest, and we see interest and opportunity for Open Seattle to be involved in these events.
 
 #### Educational events & projects
 
 **Focus more on speaker events, project pitch/demo nights, unconferences, & ongoing programs than hackathons**
 
-Code for Seattle has successfully organized a number of one-day events, and in 2015 we'll be putting more effort toward ongoing events that happen over a period of weeks or months.
+Open Seattle has successfully organized a number of one-day events, and in 2015 we'll be putting more effort toward ongoing events that happen over a period of weeks or months.
 
 
 **Improve nwdata.org, a regional guide to open data**
@@ -67,19 +67,19 @@ The Pacific Northwest has a substantial amount of open data available, and nwdat
 
 We want to increase our outreach, which we see as critical for making it easy to participate. Partially we hope to do this by attending, participating and promoting civic data at other events. Specifically, we're interested in targetting events like the Makers Faire in the summer, and course material to get civic data into the various coding bootcamps offered around the city.
 
-One challenge Code for Seattle has struggled with is doing promotion of projects with the purpose of connecting volunteers and other resources with project leaders. We'll be revising the way our project list at codeforseattle.org/projects is maintained, including integrating the list with CFAPI & The Civic Tech Issue Tracker.
+One challenge Open Seattle has struggled with is doing promotion of projects with the purpose of connecting volunteers and other resources with project leaders. We'll be revising the way our project list at openseattle.org/projects is maintained, including integrating the list with CFAPI & The Civic Tech Issue Tracker.
 
-In addition, we'll start a series of posts on codeforseattle.org that profile project leaders and volunteers that help the community learn more about what projects people are working on and who is involved.
+In addition, we'll start a series of posts on openseattle.org that profile project leaders and volunteers that help the community learn more about what projects people are working on and who is involved.
 
 #### Creating a paid position
 
-Finally, we want to formalize some of the process of the brigade, and will begin investigating the possibility of creating a paid code for seattle organization and outreach position / fellowship. There's a lot of administrative work around the brigade, and we believe the organization could grow much faster with dedicated time spent responding to emails, proactively reaching out to manage event logistics, and forging community partnership. 
+Finally, we want to formalize some of the process of the brigade, and will begin investigating the possibility of creating a paid Open Seattle organization and outreach position / fellowship. There's a lot of administrative work around the brigade, and we believe the organization could grow much faster with dedicated time spent responding to emails, proactively reaching out to manage event logistics, and forging community partnership. 
 
 
 ### Outcomes
 
 - Increased event attendance
-- Examples of popular projects affiliated with Code for Seattle
+- Examples of popular projects affiliated with Open Seattle
 - New open Seattle datasets available
 
 
@@ -117,5 +117,5 @@ total: $2,400
 
 ---
 
-_This is a work-in-progress plan for Code for Seattle's events & programs in 2015. You can contribute! Suggest edits to this page [via GitHub](https://github.com/codeforseattle/codeforseattle.github.com/blob/master/plan/2015.md)._
+_This is a work-in-progress plan for Open Seattle's events & programs in 2015. You can contribute! Suggest edits to this page [via GitHub](https://github.com/openseattle/openseattle.github.io/blob/master/plan/2015.md)._
 

--- a/projects/index.csv
+++ b/projects/index.csv
@@ -1,12 +1,15 @@
 name,description,link_url,code_url,type,categories,status
+http://fatalencounters.org/,"Largest directory of US citizens killed by police officers. Includes searchable/filterable list, visualizations, submissions pipeline, open data api, data management panel.",https://github.com/JustOpenSource/fatalshootings,https://github.com/JustOpenSource/fatalshootings,,,in development
 nwdata.org,"A directory of data portals, apps, & other resources related to civic tech in the Pacific Northwest.",http://nwdata.org,https://github.com/sethvincent/nwdata.org,,,live
 Duwamish River Cleanup,A community of residents and stakeholders who are monitoring the cleanup of toxic waste in Seattle's Duwamish River.,http://heyduwamish.org,https://github.com/smartercleanup/duwamish,,,
 What's My Wage?,Learn what the new minimum wage should be based on your employer.,http://whatsmywage.org,https://github.com/working-wa/whats-my-wage-app,,,
-What Do I Do With...? recycling app,Dropoff locator for recyclables and other disposables in King County,www.wdidw.com,https://github.com/audreycarlsen/recycling_app,,,live/ongoing
+Seward Park Stories,"Documenting the art, historical, & cultural locations in Seward Park.",http://sewardparkstories.org,https://github.com/sethvincent/seward-park-map,,,live/ongoing
+Seattle CouncilChat,Seattle CouncilChat is a simple way to discuss the meetings of the Seattle City Council as they happen.,http://councilchat.seattle.io,https://github.com/seattleio/councilchat,,,live/ongoing
+What Do I Do With...? recycling app,Dropoff locator for recyclables and other disposables in King County,http://www.wdidw.com,https://github.com/audreycarlsen/recycling_app,,,live/ongoing
 Seattle in Progress,,http://www.seattleinprogress.com,closed source?,,,active
 Seattle LocalWiki,,http://seattlewiki.net,http://github.com/localwiki/localwiki,,,live
-LocalWiki JavaScript client,Use the data from LocalWiki in your JavaScript projects!,,https://github.com/codeforseattle/node-localwiki-client,,,
-LocalWiki Ruby client,Use the data from LocalWiki in your Ruby projects!,,https://github.com/codeforseattle/localwiki_client,,,
+LocalWiki JavaScript client,Use the data from LocalWiki in your JavaScript projects!,,https://github.com/openseattle/node-localwiki-client,,,
+LocalWiki Ruby client,Use the data from LocalWiki in your Ruby projects!,,https://github.com/openseattle/localwiki_client,,,
 Citizen Input,A crowdsourcing platform for discovering great new candidates for public office and a real-time report of each candidate's relative popularity.,http://www.citizeninput.org/,https://github.com/citizen-input-project,,,in progress
 Seattle's Heritage Trees,,http://tsibley.net/trees/seattle,https://github.com/tsibley/seattle-trees,,,live
 Seattle Miscellaneous Maps,"Mix and match maps, census, voting data for city council district demographics or anything else",http://lucasw.github.io/gmap/census.html,https://github.com/lucasw/gis,,,in progress
@@ -23,7 +26,7 @@ Seattle Open Data Policy proposal,"",,http://bit.ly/SeattleDataPolicy,,,
 Seattle Data Inventory,An inventory of the most interesting data available from data.seattle.gov,,http://seattlewiki.net/Open_Data_Resources,,,
 Realtime Transit Data,,http://domoritz.de/live-bus-seattle/#12/47.6210/-122.3328,https://github.com/domoritz/live-bus-seattle,,,
 Stolen Bike App,,http://bike.jumis.com/index.html,https://github.com/lcdvirgo/stolenbikesSEA,,,
-Seattle Icons,,seattleicons.org,http://github.com/codeforseattle/seattle-icons,,,
-Seattle Metro Cuts,,codeforseattle.org/metrocuts,http://github.com/codeforseattle/metrocuts,,,
+Seattle Icons,,seattleicons.org,http://github.com/openseattle/seattle-icons,,,
+Seattle Metro Cuts,,openseattle.org/metrocuts,http://github.com/openseattle/metrocuts,,,
 Washington Homelessness,Goal is to provide a dashboard to access & visualize open data for homelessness,livingwa.github.io,https://github.com/livingwa,,,
 Deglassified,A map of businesses with policies against Google Glass.,deglassified.com,https://github.com/licyeus/deglassified,,,live

--- a/projects/index.html
+++ b/projects/index.html
@@ -5,7 +5,7 @@ title: CfS Projects
 
 <div class="projects">
 
-<p>Take a look at some Seattle-based civic technology projects! Some of these are worked on at Code for Seattle meetups and some are great local examples of civic tech projects.</p>
+<p>Take a look at some Seattle-based civic technology projects! Some of these are worked on at Open Seattle meetups and some are great local examples of civic tech projects.</p>
 
 {% for project in site.data.projects %}
   <h3>{{ project.name }}</h3>
@@ -66,8 +66,8 @@ title: CfS Projects
 
 </div>
 
-<h2 style="margin-bottom:10px;">Get updates about Code for Seattle projects</h2>
-<p>Join the Code for Seattle email newsletter to get updates about our projects. Emails are sent once a month, and provide a look at what's new with CfS.</p>
+<h2 style="margin-bottom:10px;">Get updates about Open Seattle projects</h2>
+<p>Join the Open Seattle email newsletter to get updates about our projects. Emails are sent once a month, and provide a look at what's new with CfS.</p>
 <div>{% include newsletter.html %}</div>
 <script src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
 <script src="/js/app.js">// This space intentionally left blank</script>


### PR DESCRIPTION
Please let me know if I missed anything. I left the URL SLUG for 2014-07-30-new-to-civic-technology-code-for-seattle-project-ideas unchanged.
