### PR TITLE
Fixed broken links on the site

### DIFF
--- a/pages/contact.md
+++ b/pages/contact.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: "Contact us"
+permalink: /contact/
 ---
 
 ## Email the organizers of Open Seattle:

--- a/pages/events.md
+++ b/pages/events.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Events
+permalink: /events/
 ---
 
 This is a list of events organized by Open Seattle & the events of other organizations that are relevant to civic engagement & technology.
@@ -47,5 +48,3 @@ Please join us for Electric Sky, an art and tech weekend campathon bringing toge
 <h2>Join our meetup group to get event announcements</h2>
 <p>On our meetup group we announce the weekly civic hacking nights, hackathons, and other events.</p>
 <p><a href="http://meetup.com/openseattle" class="button" target="_blank">Join the CfS meetup group</a></p>
-
-


### PR DESCRIPTION
Hi all. 

Links to "Contact" and "Events" pages were broken, resulting GitHub 404 error message. 

Looks like the permalink was missing from the pages so this caused the error. 

This has been now fixed.

Thank you.
