### PR TITLE
Create Seattle-s First Environmental Justice Hackathon on April 28-29…

### DIFF
--- a/pages/Seattle-s First Environmental Justice Hackathon on April 28-29 2017.md
+++ b/pages/Seattle-s First Environmental Justice Hackathon on April 28-29 2017.md
@@ -1,0 +1,29 @@
+Seattle’s First Environmental Justice Hackathon
+ 
+ 
+50 people gathered at Facebook on April 28-29th, 2017 for the first-ever environmental justice (EJ) hackathon in Seattle. They quickly organized into groups, based on ideas they had pitched the week before in a Facebook group with scaffolding from organizers. 
+ 
+These ideas were built overnight: 
+CO2 Life cycle analysis: a database & tool that makes it easy to see—and understand—the environmental impact of products you might buy.
+ 
+Waste Buddy: a quiz game that teaches you what to compost and recycle your waste
+Farmer Connect: an app that connects to local farmers near you and makes it easier to shop for what’s available by listing current items.
+ 
+Act Now!: an app to help you discover the legislative priorities for organizations you care about, and how yours align to theirs. 
+ 
+Public Testimony Supercharge Tool: web-based, printable templates to help citizens write their public testimonies and print them to go. 
+ 
+Carbon Footprint Calculator in Maps: a map to plot your route to your intended destination, it will calculate your carbon footprint based on the transportation mode (car, public transport, walking) chosen.
+ 
+Automated Contacts Databasing Tool: a tool to collect sign-in sheets and business cards to make it easier to organize contacts
+ 
+Expose: A platform to provide transparency and change perspectives on how people view companies & organizations.
+ 
+With so many tech people looking to make a difference and contribute, hackathons have become a mundane way to organize snapshot collaborations with organizations focused on bringing an issue to light. But grassroots organizers Tiffany Chan, Derek Hoshiko and Josh Epstein, alongside programmers Thomas Lai, Gary Wong and Alan Hsu and the team’s cheerleader Sage Miller, wanted to make sure they had enough ideas to attract enough participants from the EJ side. The event was well-represented by people of color, youth and members of LGBT community - rare demographics featured at hackathons. 
+
+The mandate for diversity was made possible by three one-hour symposiums themed PAST, PRESENT and FUTURE that explored the environmental justice movement and served as a platform onto which to workshop entry points for those did not possess background in EJ.
+The learning curve was even higher for environmental justice advocates, who had yet to experience working directly with developers and engineers. The general ethos of the hackathon - its emphasis on rapid prototyping and design to solve everyday, large-scale problems - was unknown to many, who came back the next day and pulled their peers from other weekend activities to participate. 
+ 
+After interviewing several participants, I discovered that those who had missed the brainstorm session online would have benefited from being exposed to the process of pitching and getting feedback on ideas in-person, in the first hour instead of being presented with the ideas on whiteboards at the start of the event.  A revision to our format the team of organizers behind the EJ hacks will certainly take into account for future events.
+
+Call to action: More importantly, the first environmental justice hackathon in Seattle benefits from the strong presence of civic tech groups in Seattle to spearhead efforts to scale these solutions. Now that the projects are archived, two Open Seattle organizers will work hard to connect interested teams to opportunities for continuing this work and value news of any related project that bridges the worlds of technology and climate change activism. 


### PR DESCRIPTION
# **Seattle’s First Environmental Justice Hackathon**
 
50 people gathered at Facebook on April 28-29th, 2017 for the first-ever environmental justice (EJ) hackathon in Seattle. They quickly organized into groups, based on ideas they had pitched the week before in a Facebook group with scaffolding from organizers. 
 
These ideas were built overnight: 

1. **CO2 Life cycle analysis:** a database & tool that makes it easy to see—and understand—the environmental impact of products you might buy.

2. **Waste Buddy:** a quiz game that teaches you what to compost and recycle your waste
Farmer Connect: an app that connects to local farmers near you and makes it easier to shop for what’s available by listing current items.

3. **Act Now!:** an app to help you discover the legislative priorities for organizations you care about, and how yours align to theirs. 

4. **Public Testimony Supercharge Tool:** web-based, printable templates to help citizens write their public testimonies and print them to go. 

5. **Carbon Footprint Calculator in Maps:** a map to plot your route to your intended destination, it will calculate your carbon footprint based on the transportation mode (car, public transport, walking) chosen.

6. **Automated Contacts Databasing Tool:** a tool to collect sign-in sheets and business cards to make it easier to organize contacts

7. **Expose:** A platform to provide transparency and change perspectives on how people view companies & organizations.

With so many tech people looking to make a difference and contribute, hackathons have become a mundane way to organize snapshot collaborations with organizations focused on bringing an issue to light. But grassroots organizers Tiffany Chan, Derek Hoshiko and Josh Epstein, alongside programmers Thomas Lai, Gary Wong and Alan Hsu and the team’s cheerleader Sage Miller, wanted to make sure they had enough ideas to attract enough participants from the EJ side. The event was well-represented by people of color, youth and members of LGBT community - rare demographics featured at hackathons. 

The mandate for diversity was made possible by three one-hour symposiums themed PAST, PRESENT and FUTURE that explored the environmental justice movement and served as a platform onto which to workshop entry points for those did not possess background in EJ.

The learning curve was even higher for environmental justice advocates, who had yet to experience working directly with developers and engineers. The general ethos of the hackathon - its emphasis on rapid prototyping and design to solve everyday, large-scale problems - was unknown to many, who came back the next day and pulled their peers from other weekend activities to participate. 
 
After interviewing several participants, I discovered that those who had missed the brainstorm session online would have benefited from being exposed to the process of pitching and getting feedback on ideas in-person, in the first hour instead of being presented with the ideas on whiteboards at the start of the event.  A revision to our format the team of organizers behind the EJ hacks will certainly take into account for future events.

_**Call to action:**_ More importantly, the first environmental justice hackathon in Seattle benefits from the strong presence of civic tech groups in Seattle to spearhead efforts to scale these solutions. Now that the projects are archived, two Open Seattle organizers will work hard to connect interested teams to opportunities for continuing this work and value news of any related project that bridges the worlds of technology and climate change activism. 
