### PR TITLE
Replaced call for organizers 2018 with Slack open invite link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ title: Civic technology in Seattle, WA
       <li class="nav-item landing-nav-item"><a class="landing-nav-link" href="/blog">blog</a></li>
       <li class="nav-item landing-nav-item"><a class="landing-nav-link" href="/projects">projects</a></li>
       <li class="nav-item landing-nav-item"><a class="landing-nav-link" href="/events">events</a></li>
-      <li class="nav-item landing-nav-item"><a class="landing-nav-link" href="/lead-organizer-application">apply to be a 2018 organizer</a></li>
+      <li class="nav-item landing-nav-item"><a class="landing-nav-link" href="https://join.slack.com/t/openseattle/shared_invite/enQtNTMyNTU1MTUwODE5LWM3ZTk3ZjM0MjRiNDgwNzczZTYxNTllY2YwNDIyYWViYTQxY2IzMDBjN2JiZTM2MGFkZTIwNzZmNjU5OTUwY2Y">join our slack</a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
A very simple change to replace the out of date call for organizers 2018 with a now open slack invite link:

Old banner with nav links: 
<img width="804" alt="open_sea_old_banner" src="https://user-images.githubusercontent.com/17132317/51764164-4a42a200-2089-11e9-9850-7cd23f62401d.png">

New banner with nav links:
<img width="886" alt="open_sea_new_banner" src="https://user-images.githubusercontent.com/17132317/51764176-53337380-2089-11e9-875f-be43cb6486c4.png">
