### PR TITLE
Update link to join slack

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ title: Civic technology in Seattle, WA
       <li class="nav-item landing-nav-item"><a class="landing-nav-link" href="/blog">blog</a></li>
       <li class="nav-item landing-nav-item"><a class="landing-nav-link" href="/projects">projects</a></li>
       <li class="nav-item landing-nav-item"><a class="landing-nav-link" href="/events">events</a></li>
-      <li class="nav-item landing-nav-item"><a class="landing-nav-link" href="https://join.slack.com/t/openseattle/shared_invite/enQtNTMyNTU1MTUwODE5LWM3ZTk3ZjM0MjRiNDgwNzczZTYxNTllY2YwNDIyYWViYTQxY2IzMDBjN2JiZTM2MGFkZTIwNzZmNjU5OTUwY2Y">join our slack</a></li>
+      <li class="nav-item landing-nav-item"><a class="landing-nav-link" href="https://join.slack.com/t/openseattle/shared_invite/enQtNzczMjg5MzYyNzg4LTgwZDExYmE2MWQ4N2ZiN2VmNDllMmU3ODI0YWFkMTQ5ODY4MGMwNDBhOTQwNTU3OGJmYTI5ZTE3YWQ2NTdjYWY">join our slack</a></li>
     </ul>
   </div>
 </div>
@@ -21,8 +21,8 @@ title: Civic technology in Seattle, WA
   <div class="container">
     <div class="page-section clearfix">
       <h2 class="page-section-header">Open source & local communities</h2>
-      <p>Open Seattle advocates for open data and civic technology projects that improve the lives of Seattle residents. 
-        <br> We host monthly meetups where members pitch and work on projects, and build relationships between tech workers, community groups, and local government. </br> 
+      <p>Open Seattle advocates for open data and civic technology projects that improve the lives of Seattle residents.
+        <br> We host monthly meetups where members pitch and work on projects, and build relationships between tech workers, community groups, and local government. </br>
       </p>
     </div>
 
@@ -54,12 +54,12 @@ title: Civic technology in Seattle, WA
 
     <div class="page-section clearfix">
       <h2 class="page-section-header">Get Involved</h2>
-      <p>Open Seattle meets on the fourth Wednesday of every month to discuss and work on civic technology projects. RSVP for our next meetup and keep track of all of our events on our <a href="http://meetup.com/openseattle" target="_blank">Meetup page</a>. 
+      <p>Open Seattle meets on the fourth Wednesday of every month to discuss and work on civic technology projects. RSVP for our next meetup and keep track of all of our events on our <a href="http://meetup.com/openseattle" target="_blank">Meetup page</a>.
         <br />
         <p>Want to pitch a project at our next meetup? <a href="https://docs.google.com/forms/d/e/1FAIpQLSdJ8Pt6AbuVoGmKqz7M784XF7BXoAhwWygDN_wLW1U6Rwuonw/viewform">Get in touch!</a></p>
 </div>
     <hr>
-    
+
         <div class="page-section clearfix">
       <h2 class="page-section-header">Join Our Mailing List</h2>
       <p>Get updates on projects, upcoming events, and local civic tech news.</p>
@@ -79,7 +79,7 @@ title: Civic technology in Seattle, WA
       </ul>
       <!-- <p><a href="/sponsor">Become a sponsor of Open Seattle</a></p> -->
     </div>
-    
+
   </div>
 </main>
 


### PR DESCRIPTION
The invite link to join the Open Seattle slack org was out of date. This simply updates the link to be valid once again.